### PR TITLE
Add tank level control example

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,10 +87,11 @@
 		<script src="js/models/DoublePendulum.js"></script>
 		<script src="js/models/BlockOnSlope.js"></script>
 		<script src="js/models/Vehicle.js"></script>
-		<script src="js/models/Multirotor.js"></script>
-		<script src="js/models/CruiseControl.js"></script>
-		<script src="js/models/BouncingBallPlatform.js"></script>
-		<script src="js/models/Airplane.js"></script>
+                <script src="js/models/Multirotor.js"></script>
+                <script src="js/models/CruiseControl.js"></script>
+                <script src="js/models/BouncingBallPlatform.js"></script>
+                <script src="js/models/TankLevel.js"></script>
+                <script src="js/models/Airplane.js"></script>
 
 		<script src="js/levels/RocketLandingNormal.js"></script>
 		<script src="js/levels/RocketLandingUpsideDown.js"></script>
@@ -112,9 +113,10 @@
 		<script src="js/levels/CruiseControl2.js"></script>
 		<script src="js/levels/BallOnPlatformBalance.js"></script>
 		<script src="js/levels/BallOnPlatformBounce.js"></script>
-		<script src="js/levels/BallOnPlatformEdgeBalance.js"></script>
-		<script src="js/levels/AirplaneIntro.js"></script>
-		<script src="js/levels/AirplaneLanding.js"></script>
+                <script src="js/levels/BallOnPlatformEdgeBalance.js"></script>
+                <script src="js/levels/AirplaneIntro.js"></script>
+                <script src="js/levels/AirplaneLanding.js"></script>
+                <script src="js/levels/TankLevelControl.js"></script>
 
 		<script src="js/ImageDataCache.js"></script>
 		<script src="js/utils.js"></script>

--- a/js/levels/TankLevelControl.js
+++ b/js/levels/TankLevelControl.js
@@ -1,0 +1,26 @@
+'use strict';
+if (typeof Levels === 'undefined') var Levels = {};
+
+Levels.TankLevelControl = function()
+{
+    this.name = "TankLevelControl";
+    this.title = "Controle de N\u00edvel do Tanque";
+    this.boilerPlateCode = "function controlFunction(tank){\n  return 0.5;\n};";
+    this.sampleSolution = "var integral = 0;\nfunction controlFunction(tank){\n  var erro = tank.targetLevel - tank.level;\n  if(Math.abs(erro) < 0.5) integral += 0.02 * erro;\n  var valv = 0.8 * erro + 0.5 * integral;\n  monitor('erro',erro);\n  monitor('integral',integral);\n  monitor('valve',valv);\n  return valv;\n};";
+    this.difficultyRating = 1;
+    this.description = "Mantenha o n\u00edvel (linha magenta) por 5 segundos.";
+    this.model = new Models.TankLevel({});
+}
+
+Levels.TankLevelControl.prototype.levelComplete = function(){return this.model.holdTimer > 5;}
+
+Levels.TankLevelControl.prototype.levelFailed = function(){return false;}
+
+Levels.TankLevelControl.prototype.simulate = function (dt, controlFunc)
+{ this.model.simulate (dt, controlFunc); }
+
+Levels.TankLevelControl.prototype.getSimulationTime = function() {return this.model.T;}
+
+Levels.TankLevelControl.prototype.draw = function(ctx, canvas){this.model.draw(ctx, canvas);}
+
+Levels.TankLevelControl.prototype.infoText = function(ctx, canvas){return this.model.infoText();}

--- a/js/models/TankLevel.js
+++ b/js/models/TankLevel.js
@@ -1,0 +1,73 @@
+'use strict';
+if (typeof Models === 'undefined') var Models = {};
+
+Models.TankLevel = function(params)
+{
+    var nVars = Object.keys(this.vars).length;
+    for(var i = 0; i < nVars; i++)
+    {
+        var key = Object.keys(this.vars)[i];
+        this[key] = (typeof params[key] == 'undefined')?this.vars[key]:params[key];
+    }
+}
+
+Models.TankLevel.prototype.vars =
+{
+    area: 1.0,
+    level: 0.5,
+    valve: 0.0,
+    valve_cmd: 0.0,
+    maxInFlow: 1.0,
+    outflowCoeff: 0.5,
+    targetLevel: 1.0,
+    holdTimer: 0.0,
+    T: 0,
+};
+
+Models.TankLevel.prototype.simulate = function (dt, controlFunc)
+{
+    var input = controlFunc({level:this.level,targetLevel:this.targetLevel,T:this.T});
+    if(typeof input != 'number')
+        throw "Erro: a controlFunction deve retornar um n\u00famero.";
+    this.valve_cmd = Math.max(0, Math.min(1, input));
+    integrationStep(this, ['level', 'valve'], dt);
+
+    if(Math.abs(this.level - this.targetLevel) < 0.02 && Math.abs(this.valve_cmd - this.valve) < 0.05)
+        this.holdTimer += dt;
+    else
+        this.holdTimer = 0;
+}
+
+Models.TankLevel.prototype.ode = function (x) {
+    var level = x[0];
+    var valve = x[1];
+    var inflow = this.maxInFlow * valve;
+    var outflow = this.outflowCoeff * Math.sqrt(Math.max(level,0));
+    return [ (inflow - outflow)/this.area, 5.0 * (this.valve_cmd - valve) ];
+}
+
+Models.TankLevel.prototype.draw = function (ctx, canvas) {
+    var tankWidth = 2.0;
+    var tankHeight = 2.0;
+    ctx.save();
+    ctx.translate(-tankWidth/2,0);
+    ctx.strokeStyle = '#333366';
+    ctx.lineWidth = 0.05;
+    ctx.strokeRect(0,0,tankWidth,tankHeight);
+
+    ctx.fillStyle = '#44aaff';
+    var h = Math.max(0, Math.min(tankHeight, this.level));
+    ctx.fillRect(0,0,tankWidth,h);
+
+    ctx.strokeStyle = '#ff00ff';
+    drawLine(ctx,0,this.targetLevel,tankWidth,this.targetLevel,0.02);
+
+    ctx.restore();
+}
+
+Models.TankLevel.prototype.infoText = function ()
+{
+    return  "tank.level = " + round(this.level,2)
+        + "\ntank.valve = " + round(this.valve,2)
+        + "\ntank.T     = " + round(this.T,2);
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -167,6 +167,9 @@ CC.levelGroups = {
         RocketLandingMulti: 'Múltiplos',
         RocketLandingHoverslam: 'Hoverslam',
     },
+    'Controle de Nível': {
+        TankLevelControl: 'Tanque',
+    },
     'Direção': {
         VehicleSteeringSimple: 'Introdução',
         VehicleRacing: 'Corrida',


### PR DESCRIPTION
## Summary
- implement new TankLevel model with valve and outflow dynamics
- create TankLevelControl level that asks players to keep the level for 5 s
- register new level group "Controle de Nível" and load scripts
- remove binary thumbnail that prevented PR creation

## Testing
- `node --check js/models/TankLevel.js`
- `node --check js/levels/TankLevelControl.js`
- `node --check js/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68756cfc1f20832c8746b6492eb426fe